### PR TITLE
corrected error with registering new user.

### DIFF
--- a/src/main/java/com/pickaflick/authorizations/WebSecurityConfig.java
+++ b/src/main/java/com/pickaflick/authorizations/WebSecurityConfig.java
@@ -37,7 +37,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
       .csrf().disable()
       .authorizeRequests()
 //      change back to this when we are done testing..."/**" allows all testing without passing auth tokens:
-      .antMatchers(HttpMethod.POST, "SIGN_UP_URL").permitAll()   
+      .antMatchers(HttpMethod.POST, "/api/users/add").permitAll()   
 //      .antMatchers("/**").permitAll()
       .anyRequest().authenticated()
       .and()


### PR DESCRIPTION
For some reason we were getting error trying to register new user, updated allowed POST path to be actual URL instead of using SIGN_UP_URL constant from AuthConstants file, now it works.